### PR TITLE
Update Vancouver time whenever user chooses a city to compare.

### DIFF
--- a/js/loader.js
+++ b/js/loader.js
@@ -65,6 +65,7 @@ $(function () {
             var name = this.name.split("/");
             $labelName.text('@' + name[1]);
             $labelTime.text(m.format("LT"));
+            $vancouver.html('@Vancouver ' + moment.tz(Date.now(), "America/Vancouver").format('LT'));
             $axisX.css('left', this.x * 100 + '%');
             $axisY.css('top', this.y * 100 + '%');
         },


### PR DESCRIPTION
Whenever the user hovers the map to choose a city for time comparison, this change will update Vancouver time as well as the selected city time.

I couldn't find a way to reproduce it locally, so I tried this change over Chrome Dev Tools on the [deployed version](https://cleiver.github.io/vanclock/).

Thanks again for taking the time to build an awesome tool.